### PR TITLE
Initializing Metric Client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ goreleaser: clean
 
 # test components of plugin/gcp
 testgcp:
-	go test -v ./plugin/gcp
+	go test -v ./plugin/gcp -count=1

--- a/plugin/gcp/README.md
+++ b/plugin/gcp/README.md
@@ -15,19 +15,6 @@
     - 
 
 
-## Metric Request
-
-| Component | Description|
-|-----------|------------|
-| Name | "projects/`<project-id>`" |
-|Filter| metric name and resource(instance,device) |
-|Interval| start and end time for the metrics |
-|Aggregation| reformat for each data point |
-
-
-
-
-
 TODO:
 
  - Metrics Client

--- a/plugin/gcp/README.md
+++ b/plugin/gcp/README.md
@@ -15,6 +15,18 @@
     - 
 
 
+## Metric Request
+
+| Component | Description|
+|-----------|------------|
+| Name | "projects/`<project-id>`" |
+|Filter| metric name and resource(instance,device) |
+|Interval| start and end time for the metrics |
+|Aggregation| reformat for each data point |
+
+
+
+
 
 TODO:
 
@@ -22,15 +34,15 @@ TODO:
     - Close metrics client
 
  - Metrics to collect:
-    - "CPUUtilization",
+    - "CPUUtilization" ~> `compute.googleapis.com/instance/cpu/utilization`
 
-    - "NetworkIn",
-    - "NetworkOut",
+    - "NetworkIn" ~> `compute.googleapis.com/instance/network/received_bytes_count`
+    - "NetworkOut" ~> `compute.googleapis.com/instance/network/sent_bytes_count`
 
-    - "mem_used_percent",
+    - "mem_used_percent" ~> `compute.googleapis.com/instance/memory/balloon/ram_size`/`compute.googleapis.com/instance/memory/balloon/ram_used`
 
-    - "VolumeReadBytes",
-    - "VolumeWriteBytes",
+    - "VolumeReadBytes" ~> `compute.googleapis.com/instance/disk/read_bytes_count`
+    - "VolumeWriteBytes" ~> `compute.googleapis.com/instance/disk/write_bytes_count`
 
-    - "VolumeReadOps",
-    - "VolumeWriteOps",
+    - "VolumeReadOps" ~> `compute.googleapis.com/instance/disk/read_ops_count`
+    - "VolumeWriteOps" ~> `compute.googleapis.com/instance/disk/write_ops_count`

--- a/plugin/gcp/metrics.go
+++ b/plugin/gcp/metrics.go
@@ -1,0 +1,26 @@
+package gcp
+
+import (
+	"context"
+
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+)
+
+type CloudMonitoring struct {
+	client *monitoring.MetricClient
+	GCP
+}
+
+func (c *CloudMonitoring) InitializeClient(ctx context.Context) error {
+
+	c.GCP.GetCredentials(ctx)
+
+	metricClient, err := monitoring.NewMetricClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	c.client = metricClient
+
+	return nil
+}

--- a/plugin/gcp/metrics.go
+++ b/plugin/gcp/metrics.go
@@ -2,13 +2,24 @@ package gcp
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type CloudMonitoring struct {
 	client *monitoring.MetricClient
 	GCP
+}
+
+func NewCloudMonitoring(scopes []string) *CloudMonitoring {
+	return &CloudMonitoring{
+		GCP: NewGCP(scopes),
+	}
 }
 
 func (c *CloudMonitoring) InitializeClient(ctx context.Context) error {
@@ -23,4 +34,50 @@ func (c *CloudMonitoring) InitializeClient(ctx context.Context) error {
 	c.client = metricClient
 
 	return nil
+}
+
+func (c *CloudMonitoring) CloseClient() error {
+	err := c.client.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CloudMonitoring) NewMetricRequest(metricName string, instanceID string) *monitoringpb.ListTimeSeriesRequest {
+
+	endtime := time.Now()
+	starttime := endtime.Add(-24 * 1 * time.Hour) // 24 hours before current time
+
+	request := &monitoringpb.ListTimeSeriesRequest{
+		Name: fmt.Sprintf("projects/%s", c.ProjectID),
+		Filter: fmt.Sprintf(
+			`metric.type="%s" AND resource.labels.instance_id="%s"`,
+			metricName,
+			instanceID,
+		),
+		Interval: &monitoringpb.TimeInterval{
+			EndTime:   timestamppb.New(endtime),
+			StartTime: timestamppb.New(starttime),
+		},
+		Aggregation: &monitoringpb.Aggregation{
+			AlignmentPeriod: durationpb.New(time.Minute),
+		},
+		View: monitoringpb.ListTimeSeriesRequest_FULL,
+	}
+
+	return request
+}
+
+func (c *CloudMonitoring) GetMetric(request *monitoringpb.ListTimeSeriesRequest) *monitoringpb.TimeSeries {
+
+	it := c.client.ListTimeSeries(context.Background(), request)
+
+	resp, err := it.Next()
+	if err != nil {
+		panic(err)
+	}
+
+	return resp
+
 }

--- a/plugin/gcp/metrics_test.go
+++ b/plugin/gcp/metrics_test.go
@@ -1,0 +1,43 @@
+package gcp
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+)
+
+// run this test as
+//
+//	`TEST_INSTANCE_ID="<an-instance-id>" make testgcp`
+func TestGetMetrics(t *testing.T) {
+
+	id := os.Getenv("TEST_INSTANCE_ID")
+
+	log.Printf("running %s", t.Name())
+	metric := NewCloudMonitoring(
+		[]string{
+			"https://www.googleapis.com/auth/monitoring.read",
+		},
+	)
+	err := metric.InitializeClient(context.Background())
+	if err != nil {
+		t.Errorf("[%s]: %s", t.Name(), err.Error())
+	}
+
+	request := metric.NewMetricRequest(
+		"compute.googleapis.com/instance/cpu/utilization",
+		id,
+	)
+
+	resp := metric.GetMetric(request)
+
+	log.Printf("metrics: %s", resp.GetMetric().String())
+	log.Printf("resource: %s", resp.GetResource().String())
+
+	for _, point := range resp.Points {
+		log.Printf("Point : %s", point.String())
+	}
+
+	metric.CloseClient()
+}

--- a/plugin/gcp/metrics_test.go
+++ b/plugin/gcp/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 )
 
 // run this test as
@@ -12,9 +13,14 @@ import (
 //	`TEST_INSTANCE_ID="<an-instance-id>" make testgcp`
 func TestGetMetrics(t *testing.T) {
 
+	//test variables
 	id := os.Getenv("TEST_INSTANCE_ID")
+	endtime := time.Now()
+	starttime := endtime.Add(-24 * 1 * time.Hour) // 24 hours before current time
 
 	log.Printf("running %s", t.Name())
+
+	// creating and initializing client
 	metric := NewCloudMonitoring(
 		[]string{
 			"https://www.googleapis.com/auth/monitoring.read",
@@ -25,19 +31,25 @@ func TestGetMetrics(t *testing.T) {
 		t.Errorf("[%s]: %s", t.Name(), err.Error())
 	}
 
-	request := metric.NewMetricRequest(
+	// creating the metric request for the instance
+	request := metric.NewInstanceMetricRequest(
 		"compute.googleapis.com/instance/cpu/utilization",
 		id,
+		starttime,
+		endtime,
+		60,
 	)
 
+	// execute the request
 	resp := metric.GetMetric(request)
 
 	log.Printf("metrics: %s", resp.GetMetric().String())
 	log.Printf("resource: %s", resp.GetResource().String())
+	log.Printf("# of points: %d", len(resp.Points))
 
-	for _, point := range resp.Points {
-		log.Printf("Point : %s", point.String())
-	}
+	// for _, point := range resp.Points {
+	// 	log.Printf("Point : %.10f", point.GetValue().GetDoubleValue())
+	// }
 
 	metric.CloseClient()
 }


### PR DESCRIPTION
Fixes #5 

- A mapping of metrics we can potentially use, as a counterpart of our current AWS metrics.
- Initializing metric client and gathering metrics for a particular resource, here compute instance.
- This will be extended to create a job for collecting various metrics for all resources.
